### PR TITLE
fix: #5 日付比較のタイムゾーン問題を修正

### DIFF
--- a/src/app/api/v1/summary/daily/route.ts
+++ b/src/app/api/v1/summary/daily/route.ts
@@ -10,6 +10,7 @@ import {
   MealType,
   Nutrition,
 } from "@/lib/meals";
+import { getDateRange } from "@/lib/utils";
 
 /**
  * GET /api/v1/summary/daily
@@ -84,11 +85,15 @@ export async function GET(request: NextRequest) {
       carbohydrate: user.dailyCarbTarget || 300,
     };
 
-    // 該当日の食事記録を取得
+    // 該当日の食事記録を取得（@db.Dateフィールドとの比較のため範囲検索を使用）
+    const range = getDateRange(date);
     const meals = await prisma.mealRecord.findMany({
       where: {
         userId,
-        recordDate: new Date(date),
+        recordDate: {
+          gte: range.start,
+          lt: range.end,
+        },
       },
       include: {
         mealItems: true,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,34 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * 日付文字列（YYYY-MM-DD）をUTC日付オブジェクトに変換
+ * Prismaの@db.Dateフィールドとの比較用
+ */
+export function parseToUTCDate(dateString: string): Date {
+  return new Date(dateString + "T00:00:00.000Z");
+}
+
+/**
+ * 日付の範囲を取得（開始日と翌日）
+ * @db.Dateフィールドの範囲検索用
+ */
+export function getDateRange(dateString: string): { start: Date; end: Date } {
+  const start = parseToUTCDate(dateString);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { start, end };
+}
+
+/**
+ * 月の開始日と終了日をUTCで取得
+ */
+export function getMonthRangeUTC(
+  year: number,
+  month: number
+): { start: Date; end: Date } {
+  const start = new Date(Date.UTC(year, month - 1, 1));
+  const end = new Date(Date.UTC(year, month, 1));
+  return { start, end };
+}


### PR DESCRIPTION
## Summary

- 食事記録ページで登録済みデータが表示されない問題を修正
- `@db.Date`フィールドとの比較でタイムゾーンオフセットにより日付が一致しない問題を解消
- UTCベースの日付処理に統一し、範囲検索を使用するように変更

## 変更内容

### 新規追加: `src/lib/utils.ts`
- `parseToUTCDate()`: 日付文字列（YYYY-MM-DD）をUTC日付オブジェクトに変換
- `getDateRange()`: 日付の範囲検索用（開始日〜翌日未満）
- `getMonthRangeUTC()`: 月の範囲をUTCで取得

### 修正: APIエンドポイント
- `/api/v1/meals`: 日付条件を範囲検索に変更、POST時の日付もUTC変換
- `/api/v1/summary/daily`: 日付条件を範囲検索に変更
- `/api/v1/summary/monthly`: UTCベースの日付処理に統一

## Test plan

- [x] ESLint通過
- [x] ビルド成功
- [x] 既存テスト135件パス
- [ ] 手動テスト: 食事記録を作成し、meals一覧ページで表示されることを確認
- [ ] 手動テスト: ホーム画面のカレンダーで日付を選択し、日次サマリーが表示されることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)